### PR TITLE
Fix/estilos-viewFaqs

### DIFF
--- a/src/views/FAQs/Faqs.jsx
+++ b/src/views/FAQs/Faqs.jsx
@@ -1,11 +1,12 @@
 import styles from "./Faqs.module.css"
 import Footer from "../../components/Footer/Footer"
 import NavBar from "../../components/NavBar/NavBar"
+import Encabezado from "../../components/Encabezado/Encabezado"
 import sections from "./FaqsList";
 
 import { useState } from "react";
 
-import { BsFillArrowDownCircleFill, BsFillArrowUpCircleFill } from "react-icons/bs";
+import { BsFillArrowDownCircleFill, BsFillArrowUpCircleFill, BsFillPatchQuestionFill } from "react-icons/bs";
 
 
 const Faqs = () => {
@@ -19,37 +20,38 @@ const Faqs = () => {
         }
     };
 
-    
+
 
     return (
         <>
             <NavBar />
-<div className={styles.container}>
+            <div className={styles.container}>
 
+                <Encabezado title="Preguntas Frecuentes" subtitle="Respuestas a las preguntas más comunes que nuestros clientes se suelen plantear" />
 
-            {sections.map((section, index) => (
-                <div key={index} className={styles.faqSection}>
-                    <h3 onClick={() => toggleSection(index)}>
-                        {section.title}
-                        {activeSection === index ? (
-                            <BsFillArrowUpCircleFill className={styles.icon} />
-                        ) : (
-                            < BsFillArrowDownCircleFill className={styles.icon} />
+                {sections.map((section, index) => (
+                    <div key={index} className={styles.faqSection}>
+                        <h3 onClick={() => toggleSection(index)}>
+                            {section.title}
+                            {activeSection === index ? (
+                                <BsFillArrowUpCircleFill className={styles.icon} />
+                            ) : (
+                                < BsFillArrowDownCircleFill className={styles.icon} />
+                            )}
+                        </h3>
+                        {activeSection === index && (
+                            <ul>
+                                {section.questions.map((qAndA, qIndex) => (
+                                    <li key={qIndex}>
+                                        <strong><BsFillPatchQuestionFill className={styles.iconTwo} /> {qAndA.question}</strong>
+                                        <p>{qAndA.answer}</p>
+                                    </li>
+                                ))}
+                            </ul>
                         )}
-                    </h3>
-                    {activeSection === index && (
-                        <ul>
-                            {section.questions.map((qAndA, qIndex) => (
-                                <li key={qIndex}>
-                                    <strong>{qAndA.question}</strong>
-                                    <p>{qAndA.answer}</p>
-                                </li>
-                            ))}
-                        </ul>
-                    )}
-                </div>
-            ))}
-</div>
+                    </div>
+                ))}
+            </div>
             <Footer />
         </>
     );

--- a/src/views/FAQs/Faqs.module.css
+++ b/src/views/FAQs/Faqs.module.css
@@ -1,71 +1,74 @@
 /* Mobile First */
 .container {
-    width: 70vw;
+    width: 60vw;
     margin: 0 auto;
     position: relative;
+    margin-top: 20px;
 }
 
 .faqSection {
-border-radius: 10px; 
-transition: border-color 0.3s ease-in-out;
-padding: 10px;
-border: 1px solid #767E86;
-margin-top: 30px;
-margin-bottom: 30px;
+    border-radius: 10px;
+    transition: border-color 0.3s ease-in-out;
+    padding: 15px;
+    border: 2px solid #e0e0e0;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+    margin-top: 20px;
+    margin-bottom: 30px;
+    transition: all 0.3s ease-in-out;
 }
 
 .faqSection h3 {
-  font-size: 20px;
-  color: var(--secondary-color);
-  font-family: var(--primary-font);
-  cursor: pointer;
-  padding: 10px;
+    font-size: 22px;
+    color: var(--secondary-color);
+    font-family: var(--primary-font);
+    cursor: pointer;
+    padding: 10px;
 }
 
 .faqSection ul {
-  list-style: none;
-  padding: 20px;
+    list-style: none;
+    margin: 10px 0 0 0;
 }
 
 .faqSection li {
-  margin-bottom: 10px;
-  color: var(--secondary-color);
+    margin-bottom: 10px;
+    color: var(--secondary-color);
     font-family: var(--primary-font);
-    font-size: 18px;
+    font-size: 20px;
 }
 
 .faqSection li p {
     font-family: var(--secondary-font);
     font-size: 18px;
-    color: var(--secondary-color);
+    color: var(--color-silver);
+    margin-top: 10px;
+    letter-spacing: 0.75px;
+    margin-left: 10px;
 }
 
 .faqSection:hover {
-border-color: var(--primary-color);
+    border-color: var(--primary-color);
+    transform: scale(1.02);
 }
 
 .icon {
     float: right;
-    font-size: 20px;
-    margin-top: 3px;
+    font-size: 24px;
     margin-right: 5px;
     transition: transform 0.3s ease-in-out;
-    color: #F4AE3F;
+    color: var(--primary-color);
+}
+
+.iconTwo {
+    color: var(--primary-color);
 }
 
 
 /* Media Query para Tablet (768px) */
-@media (min-width: 768px) {
-  .faqSection h3 {
-    font-size: 24px;
-  }
-}
+@media (min-width: 768px) {}
 
 /* Media Query para Desktop (992px) */
-@media (min-width: 992px) {
-
-}
+@media (min-width: 992px) {}
 
 /* Media Query para Large Desktop (1200px) */
-@media (min-width: 1200px) {
-}
+@media (min-width: 1200px) {}


### PR DESCRIPTION
Se hizo:
1. Fix estilos view Faqs: se agregaron íconos a las preguntas, se cambio el color de los bordes de las secciones, se agregó un sobreado, se agregó una transición suave con una transformación de escala al hacer hover.
2. Se agregó el encabezado con título y subtitulo de la pagina ya que decidimos separarlo en otro componente para mantener el estilo siempre.

Pendiente:
1. Con el equipo necesitamos revisar la NavBar y el footer
2. En caso de surgir mejorar seguire corrigiendo estilos pero en su mayoria la vista esta casi terminada.

Se adjunta imagen: 
![ViewFaqs](https://github.com/puravidaviajespremium/CLIENT/assets/124601449/c9a4a1c3-d618-4445-a7a3-0789907973a7)
